### PR TITLE
logs errors when parsing public keys

### DIFF
--- a/easyssh.go
+++ b/easyssh.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -80,13 +81,17 @@ func getSSHConfig(config DefaultConfig) *ssh.ClientConfig {
 	}
 
 	if config.KeyPath != "" {
-		if pubkey, err := getKeyFile(config.KeyPath); err == nil {
+		if pubkey, err := getKeyFile(config.KeyPath); err != nil {
+			log.Printf("getKeyFile: %v", err)
+		} else {
 			auths = append(auths, ssh.PublicKeys(pubkey))
 		}
 	}
 
 	if config.Key != "" {
-		if signer, err := ssh.ParsePrivateKey([]byte(config.Key)); err == nil {
+		if signer, err := ssh.ParsePrivateKey([]byte(config.Key)); err != nil {
+			log.Printf("ssh.ParsePrivateKey: %v", err)
+		} else {
 			auths = append(auths, ssh.PublicKeys(signer))
 		}
 	}

--- a/easyssh.go
+++ b/easyssh.go
@@ -82,7 +82,7 @@ func getSSHConfig(config DefaultConfig) *ssh.ClientConfig {
 
 	if config.KeyPath != "" {
 		if pubkey, err := getKeyFile(config.KeyPath); err != nil {
-			log.Printf("getKeyFile: %v", err)
+			log.Printf("getKeyFile: %v\n", err)
 		} else {
 			auths = append(auths, ssh.PublicKeys(pubkey))
 		}
@@ -90,7 +90,7 @@ func getSSHConfig(config DefaultConfig) *ssh.ClientConfig {
 
 	if config.Key != "" {
 		if signer, err := ssh.ParsePrivateKey([]byte(config.Key)); err != nil {
-			log.Printf("ssh.ParsePrivateKey: %v", err)
+			log.Printf("ssh.ParsePrivateKey: %v\n", err)
 		} else {
 			auths = append(auths, ssh.PublicKeys(signer))
 		}


### PR DESCRIPTION
It is impossible to debug why public key doesn't work because we are ignoring the returned errors.