### PR TITLE
Fix data race of Scp

### DIFF
--- a/easyssh.go
+++ b/easyssh.go
@@ -335,12 +335,12 @@ func (ssh_conf *MakeConfig) Scp(sourceFile string, etargetFile string) error {
 		return statErr
 	}
 
-	go func() {
-		w, err := session.StdinPipe()
+	w, err := session.StdinPipe()
+	if err != nil {
+		return err
+	}
 
-		if err != nil {
-			return
-		}
+	go func() {
 		defer w.Close()
 
 		fmt.Fprintln(w, "C0644", srcStat.Size(), targetFile)

--- a/easyssh.go
+++ b/easyssh.go
@@ -340,18 +340,38 @@ func (ssh_conf *MakeConfig) Scp(sourceFile string, etargetFile string) error {
 		return err
 	}
 
-	go func() {
-		defer w.Close()
-
-		fmt.Fprintln(w, "C0644", srcStat.Size(), targetFile)
+	copyF := func() error {
+		_, err := fmt.Fprintln(w, "C0644", srcStat.Size(), targetFile)
+		if err != nil {
+			return err
+		}
 
 		if srcStat.Size() > 0 {
-			io.Copy(w, src)
-			fmt.Fprint(w, "\x00")
-		} else {
-			fmt.Fprint(w, "\x00")
+			_, err = io.Copy(w, src)
+			if err != nil {
+				return err
+			}
 		}
+
+		_, err = fmt.Fprint(w, "\x00")
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	copyErrC := make(chan error, 1)
+	go func() {
+		defer w.Close()
+		copyErrC <- copyF()
 	}()
 
-	return session.Run(fmt.Sprintf("scp -tr %s", etargetFile))
+	err = session.Run(fmt.Sprintf("scp -tr %s", etargetFile))
+	if err != nil {
+		return err
+	}
+
+	err = <-copyErrC
+	return err
 }


### PR DESCRIPTION
fix DATA RACE
```
    Fix data race

    ==================
    WARNING: DATA RACE
    Write at 0x00c000397240 by goroutine 83:
      golang.org/x/crypto/ssh.(*Session).start()
          /go/pkg/mod/golang.org/x/crypto@v0.0.0-20200109152110-61a87790db17/ssh/session.go:373 +0x42
      golang.org/x/crypto/ssh.(*Session).Start()
          /go/pkg/mod/golang.org/x/crypto@v0.0.0-20200109152110-61a87790db17/ssh/session.go:293 +0x28f
      golang.org/x/crypto/ssh.(*Session).Run()
          /go/pkg/mod/golang.org/x/crypto@v0.0.0-20200109152110-61a87790db17/ssh/session.go:310 +0x50
      github.com/appleboy/easyssh-proxy.(*MakeConfig).Scp()
          /go/pkg/mod/github.com/appleboy/easyssh-proxy@v1.3.1/easyssh.go:356 +0x2e0
    ....

    Previous read at 0x00c000397240 by goroutine 72:
      golang.org/x/crypto/ssh.(*Session).StdinPipe()
          /go/pkg/mod/golang.org/x/crypto@v0.0.0-20200109152110-61a87790db17/ssh/session.go:545 +0x3d7
      github.com/appleboy/easyssh-proxy.(*MakeConfig).Scp.func1()
          /go/pkg/mod/github.com/appleboy/easyssh-proxy@v1.3.1/easyssh.go:339 +0x7c
```
We must call `session.StdinPipe` before `session.Run` or `session.StdinPipe` will return error if it's started.

The origin implementation will just silently quit, `Scp()` returning `nil`, but the file *IS NOT* copy to remote actually.

This PR also check all write to the write and returning the error if we failed to do this.