### PR TITLE
Fix send on closed channel bug in command stream function

### DIFF
--- a/easyssh.go
+++ b/easyssh.go
@@ -295,8 +295,6 @@ func (ssh_conf *MakeConfig) Stream(command string, timeout ...time.Duration) (<-
 	stderrScanner := bufio.NewScanner(stderrReader)
 
 	go func(stdoutScanner, stderrScanner *bufio.Scanner, stdoutChan, stderrChan chan string, doneChan chan bool, errChan chan error) {
-		defer close(stdoutChan)
-		defer close(stderrChan)
 		defer close(doneChan)
 		defer close(errChan)
 		defer client.Close()
@@ -313,6 +311,7 @@ func (ssh_conf *MakeConfig) Stream(command string, timeout ...time.Duration) (<-
 		resWg.Add(2)
 
 		go func() {
+			defer close(stdoutChan)
 			for stdoutScanner.Scan() {
 				stdoutChan <- stdoutScanner.Text()
 			}
@@ -320,6 +319,7 @@ func (ssh_conf *MakeConfig) Stream(command string, timeout ...time.Duration) (<-
 		}()
 
 		go func() {
+			defer close(stderrChan)
 			for stderrScanner.Scan() {
 				stderrChan <- stderrScanner.Text()
 			}


### PR DESCRIPTION
I met a panic when using easyssh as a lib

```
panic: send on closed channel goroutine 734 [running]: 
github.com/appleboy/easyssh-proxy.(*MakeConfig).Stream.func1.1(0xc00032b400, 0xc0009cc360, 0xc000674c90)
github.com/appleboy/easyssh-proxy@v1.3.2/easyssh.go:255 +0x7c created by 
github.com/appleboy/easyssh-proxy.(*MakeConfig).Stream.func1 
github.com/appleboy/easyssh-proxy@v1.3.2/easyssh.go:253 +0x285 
Error: run `/root/.tiup/components/cluster/v1.3.2/tiup-cluster` (wd:/root/.tiup/data/SQgIeNO) failed: exit status 2
```

When the command is timeout, `defer close(stdoutChan)` may be called before `stdoutScanner` read is finished.

https://github.com/appleboy/easyssh-proxy/blob/ce04db7eefa6ac5a02c4a0ce337317761eaafee0/easyssh.go#L339

One general principle of using Go channels is we should only close a channel in a sender goroutine if the sender is the only sender of the channel.