### PR TITLE
fix: close stderrChan out of child goroutine

### DIFF
--- a/easyssh.go
+++ b/easyssh.go
@@ -297,6 +297,7 @@ func (ssh_conf *MakeConfig) Stream(command string, timeout ...time.Duration) (<-
 	go func(stdoutScanner, stderrScanner *bufio.Scanner, stdoutChan, stderrChan chan string, doneChan chan bool, errChan chan error) {
 		defer close(doneChan)
 		defer close(errChan)
+		defer close(stderrChan)
 		defer client.Close()
 		defer session.Close()
 
@@ -319,7 +320,6 @@ func (ssh_conf *MakeConfig) Stream(command string, timeout ...time.Duration) (<-
 		}()
 
 		go func() {
-			defer close(stderrChan)
 			for stderrScanner.Scan() {
 				stderrChan <- stderrScanner.Text()
 			}


### PR DESCRIPTION
I have observed panics on some specific commands:
```
panic: send on closed channel

goroutine 2017 [running]:
github.com/appleboy/easyssh-proxy.(*MakeConfig).Stream.func1(0xc0000ca0a0, 0xc00013e090, 0xc000fea168, 0x1, 0x1, 0xc000de4b80, 0xc000de4c00, 0xc000690ea0, 0xc000690f00, 0xc000690f60, ...)
	/home/allen/go/pkg/mod/github.com/appleboy/easyssh-proxy@v1.3.9/easyssh.go:340 +0x385
created by github.com/appleboy/easyssh-proxy.(*MakeConfig).Stream
	/home/allen/go/pkg/mod/github.com/appleboy/easyssh-proxy@v1.3.9/easyssh.go:297 +0x4a5
```

That the `stderrChan` is closed before timeout message is written to it.

So move the close `stderrChan` step outside the child goroutine, to make sure it's not closed before timeout.

ps, the `stdoutChan` seems ok as it is not used outside the child goroutine.