### PR TITLE
test: increase test coverage for SudoCommand function

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: setup sshd server
         run: |
-          apk add git make curl perl bash build-base zlib-dev ucl-dev
+          apk add git make curl perl bash build-base zlib-dev ucl-dev sudo
           make ssh-server
 
       - name: testing

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ssh-server:
 	cat tests/.ssh/test.pub >> /root/.ssh/authorized_keys
 	chmod 600 /root/.ssh/authorized_keys
 	# Append the following entry to run ALL command without a password for a user named drone-scp:
-	echo "drone-scp ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+	cat tests/sudoers >> /etc/sudoers.d/sudoers
 	# install ssh and start server
 	apk add --update openssh openrc
 	rm -rf /etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_dsa_key

--- a/easyssh_test.go
+++ b/easyssh_test.go
@@ -479,3 +479,20 @@ func TestRootAccount(t *testing.T) {
 	assert.True(t, isTimeout)
 	assert.NoError(t, err)
 }
+
+// TestSudoCommand
+func TestSudoCommand(t *testing.T) {
+	ssh := &MakeConfig{
+		Server:     "localhost",
+		User:       "drone-scp",
+		Port:       "22",
+		KeyPath:    "./tests/.ssh/id_rsa",
+		RequestPty: true,
+	}
+
+	outStr, errStr, isTimeout, err := ssh.Run(`sudo su - -c "whoami"`)
+	assert.Equal(t, "root\n", outStr)
+	assert.Equal(t, "", errStr)
+	assert.True(t, isTimeout)
+	assert.NoError(t, err)
+}

--- a/tests/sudoers
+++ b/tests/sudoers
@@ -1,0 +1,2 @@
+Defaults        requiretty
+drone-scp ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
- Add `sudo` to the `apk add` command in the `lint.yml` file
- Add a line to the `sudoers` file in the `Makefile`
- Add a new test for the `SudoCommand` in `easyssh_test.go`
- Create a new `sudoers` file with two new lines

ref: 

1. https://www.baeldung.com/linux/sudo-requiretty-option
2. https://www.baeldung.com/linux/edit-etc-sudoers-using-script